### PR TITLE
add read_pin function

### DIFF
--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -155,6 +155,7 @@ class IOPlacer
   void addVerLayer(int layer) { ver_layers_.insert(layer); }
   Edge getEdge(std::string edge);
   Direction getDirection(std::string direction);
+  void readIOfromFileIntoDB(odb::dbBTerm* _pin_name, odb::dbTechLayer* _layer, double _llx, double _lly, double _width, double _depth, Edge _orientation);
   void addPinGroup(PinGroup* group);
   void addTopLayerPinPattern(int layer, int x_step, int y_step,
                              int llx, int lly, int urx, int ury,
@@ -240,6 +241,7 @@ class IOPlacer
   void populateIOPlacer(std::set<int> hor_layer_idx,
                         std::set<int> ver_layer_idx);
   void commitIOPlacementToDB(std::vector<IOPin>& assignment);
+  int micronsToMfgGrid(double dist) const;
   void commitIOPinToDB(const IOPin& pin);
   void initCore(std::set<int> hor_layer_idxs, std::set<int> ver_layer_idxs);
   void initNetlist();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1581,4 +1581,70 @@ void IOPlacer::commitIOPinToDB(const IOPin& pin)
   bpin->setPlacementStatus(pin.getPlacementStatus());
 }
 
+void IOPlacer::readIOfromFileIntoDB(odb::dbBTerm* _pin_name, odb::dbTechLayer* _layer, double _llx, double _lly, double _width, double _depth, Edge _orientation)
+{
+  odb::dbTechLayer* layer = _layer;
+  odb::dbBTerm* bterm = _pin_name;
+  odb::dbSet<odb::dbBPin> bpins = bterm->getBPins();
+  odb::dbSet<odb::dbBPin>::iterator bpin_iter;
+  std::vector<odb::dbBPin*> all_b_pins;
+  for (bpin_iter = bpins.begin(); bpin_iter != bpins.end(); ++bpin_iter) {
+    odb::dbBPin* cur_b_pin = *bpin_iter;
+    all_b_pins.push_back(cur_b_pin);
+  }
+
+  for (odb::dbBPin* bpin : all_b_pins) {
+    odb::dbBPin::destroy(bpin);
+  }
+
+  int llx, lly,urx,ury,width,depth = 0;
+  width = micronsToMfgGrid(_width);
+  depth = micronsToMfgGrid(_depth);
+  llx = micronsToMfgGrid(_llx);
+  lly = micronsToMfgGrid(_lly);
+  if (_orientation == Edge::left) {
+    llx = llx;
+    lly = lly-width/2;
+    urx = llx + depth;
+    ury = lly + width;
+  }
+  
+  if (_orientation == Edge::right) {
+    llx = llx-depth;
+    lly = lly-width/2;
+    urx = llx + depth;
+    ury = lly + width;
+  }
+
+  if (_orientation == Edge::top) {
+    llx = llx-width/2;
+    lly = lly-depth;
+    urx = llx + width;
+    ury = lly + depth;
+  }
+
+  if (_orientation == Edge::bottom) {
+    llx = llx-width/2;
+    lly = lly;
+    urx = llx + width;
+    ury = lly + depth;
+  }
+  
+  odb::dbBPin* bpin = odb::dbBPin::create(bterm);
+  odb::dbBox::create(bpin, layer, llx, lly, urx, ury);
+  bpin->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+}
+
+int IOPlacer::micronsToMfgGrid(double dist) const
+{
+  odb::dbTech *tech = db_->getTech();
+  int dbu = tech->getDbUnitsPerMicron();
+  if (tech->hasManufacturingGrid()) {
+    int grid = tech->getManufacturingGrid();
+    return round(round(dist * dbu / grid) * grid);
+  }
+  else
+    return round(dist * 1e+3);
+}
+
 }  // namespace ppl

--- a/src/ppl/src/IOPlacer.i
+++ b/src/ppl/src/IOPlacer.i
@@ -232,6 +232,12 @@ run_io_placement(bool randomMode)
 }
 
 void
+run_single_io_read(odb::dbBTerm* _pin_name, odb::dbTechLayer* _layer, double _llx, double _lly, double _width, double _depth, Edge _orientation)
+{
+  getIOPlacer()->readIOfromFileIntoDB(_pin_name, _layer, _llx, _lly, _width, _depth, _orientation);
+}
+
+void
 set_report_hpwl(bool report)
 {
   getIOPlacer()->getParameters()->setReportHPWL(report);


### PR DESCRIPTION
### Background
We need to arrange pin locations according to top partition. Therefore, pin locations are read from a file. A new function is required to do this. 

### Function usage:
```
read_pin –name $pin_name –layer [1-12] –loc {x y} –width $pin_width –depth $pin_length –orientation {left|right|top|bottom}
-loc {x y}                        # Preassigns a pin at the specified location.  (point, optional)
-orientation <integer>            # For rectilinear partitions, specifies the edge along which the pins will be placed. (int, optional)
-layer {layerId}                  # Specifies the layer on which the pins will be assigned. (string, optional)
-name {pinName}                   # Specifies the pins of the specified module on which the command will run. (string, required)
-depth <float>                    # Sets the depth of the pin in microns. (float, optional)
-width <float>                    # Sets the width of the pin in microns. (float, optional)
```
